### PR TITLE
Bump to latest stack resolver, lts-13.15

### DIFF
--- a/Test.hs
+++ b/Test.hs
@@ -1,6 +1,4 @@
-
 import Quant.Time
-import Data.Monoid
 import Quant.MonteCarlo
 import Quant.YieldCurve
 import Quant.ContingentClaim

--- a/quantfin.cabal
+++ b/quantfin.cabal
@@ -10,7 +10,7 @@ name:                quantfin
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.2.0.0
+version:             0.2.0.1
 
 -- A short (one-line) description of the package.
 synopsis:            Quant finance library in pure Haskell.

--- a/src/Quant/ContingentClaim.hs
+++ b/src/Quant/ContingentClaim.hs
@@ -57,9 +57,11 @@ type ContingentClaim3 = forall a . Obs3 a => ContingentClaim a
 -- | Contingent claims with four observables.
 type ContingentClaim4 = forall a . Obs4 a => ContingentClaim a
 
+instance Semigroup (ContingentClaim a) where
+  (<>) = combine
+
 instance Monoid (ContingentClaim a) where
   mempty  = ContingentClaim []
-  mappend = combine
 
 -- |Basic element of a `ContingentClaim`.  Each element contains
 --a Time.  Each Time, the observables are stored in the map.

--- a/src/Quant/RNG/MWC64X.hs
+++ b/src/Quant/RNG/MWC64X.hs
@@ -78,8 +78,8 @@ skip (MWC64X st) d = MWC64X st'
         c'  = fromIntegral $ x' `mod` aConst :: Word32
         st' = buildWord64'' c' x''
 
-mkWord64 :: Word32 -> Word32 -> Word64
-mkWord64 a b = (fromIntegral $ a `shiftL` 32) .&. fromIntegral b
+--mkWord64 :: Word32 -> Word32 -> Word64
+--mkWord64 a b = (fromIntegral $ a `shiftL` 32) .&. fromIntegral b
 
 aConst, mConst, skipConst :: Word64
 aConst = 4294883355

--- a/src/Quant/Time.hs
+++ b/src/Quant/Time.hs
@@ -1,6 +1,6 @@
 
 module Quant.Time (
-	Time(..)
+    Time(..)
   , timeDiff
   , timeOffset
   , timeFromZero

--- a/src/Quant/VolSurf.hs
+++ b/src/Quant/VolSurf.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstrainedClassMethods #-}
 module Quant.VolSurf (
     VolSurf (..)
  ,  FlatSurf (..)

--- a/src/Quant/YieldCurve.hs
+++ b/src/Quant/YieldCurve.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstrainedClassMethods #-}
 module Quant.YieldCurve (
     YieldCurve (..)
  ,  FlatCurve (..)

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,4 @@ packages:
 extra-deps:
 - erf-native-1.0.0.1
 - polynomial-0.7.2
-resolver: lts-3.20
+resolver: lts-13.15


### PR DESCRIPTION
@boundedvariation - love your ```quantfin``` repository; been using it for quant self-study / learning purposes for a while now, namely because I love Haskell... that and quant finance has always fascinated me.

Thus, I bumped the code-base up to the latest stack resolver, and have made the necessary changes to build it cleanly, in order to ensure its availability for future learners. Thanks again for sharing your work.

<details>
<summary>Build log after changes:</summary>

```bash
$ stack clean && stack build --pedantic && echo
quantfin-0.2.0.1: unregistering (local file changes: Test.hs quantfin.cabal src/Quant/ContingentClaim.hs src/Quant/Math/Integration.hs src/Quant/Math/...)
Building all executables for `quantfin' once. After a successful build of all of them, only specified executables will be rebuilt.
quantfin-0.2.0.1: configure (lib + exe)
Configuring quantfin-0.2.0.1...
quantfin-0.2.0.1: build (lib + exe)
Preprocessing library for quantfin-0.2.0.1..
Building library for quantfin-0.2.0.1..
[ 1 of 16] Compiling Quant.Math.Integration ( src/Quant/Math/Integration.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/Math/Integration.o )
[ 2 of 16] Compiling Quant.Math.Utilities ( src/Quant/Math/Utilities.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/Math/Utilities.o )
[ 3 of 16] Compiling Quant.Math.Interpolation ( src/Quant/Math/Interpolation.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/Math/Interpolation.o )
[ 4 of 16] Compiling Quant.Models.Processes ( src/Quant/Models/Processes.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/Models/Processes.o )
[ 5 of 16] Compiling Quant.RNG.MWC64X ( src/Quant/RNG/MWC64X.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/RNG/MWC64X.o )
[ 6 of 16] Compiling Quant.Time       ( src/Quant/Time.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/Time.o )
[ 7 of 16] Compiling Quant.Types      ( src/Quant/Types.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/Types.o )
[ 8 of 16] Compiling Quant.ContingentClaim ( src/Quant/ContingentClaim.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/ContingentClaim.o )
[ 9 of 16] Compiling Quant.MonteCarlo ( src/Quant/MonteCarlo.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/MonteCarlo.o )
[10 of 16] Compiling Quant.VectorOps  ( src/Quant/VectorOps.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/VectorOps.o )
[11 of 16] Compiling Quant.YieldCurve ( src/Quant/YieldCurve.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/YieldCurve.o )
[12 of 16] Compiling Quant.VolSurf    ( src/Quant/VolSurf.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/VolSurf.o )
[13 of 16] Compiling Quant.Models.Merton ( src/Quant/Models/Merton.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/Models/Merton.o )
[14 of 16] Compiling Quant.Models.Heston ( src/Quant/Models/Heston.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/Models/Heston.o )
[15 of 16] Compiling Quant.Models.Dupire ( src/Quant/Models/Dupire.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/Models/Dupire.o )
[16 of 16] Compiling Quant.Models.Black ( src/Quant/Models/Black.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Quant/Models/Black.o )
Preprocessing executable 'example' for quantfin-0.2.0.1..
Building executable 'example' for quantfin-0.2.0.1..
[1 of 1] Compiling Main             ( Test.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/example/example-tmp/Main.o )
Linking .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/example/example ...
quantfin-0.2.0.1: copy/register
Installing library in /code/quantfin/.stack-work/install/x86_64-linux/lts-13.15/8.6.4/lib/x86_64-linux-ghc-8.6.4/quantfin-0.2.0.1-AkNsfB1P34a1utFYCdVYCW
Installing executable example in /code/quantfin/.stack-work/install/x86_64-linux/lts-13.15/8.6.4/bin
Registering library for quantfin-0.2.0.1..

$ stack exec example
10.515265944248924
10.515265944248924
656.1770657199078
651.7830413033989
854.4491158170529
10942.025007635908
10942.025007635908
9.800976310667839e-2
```

</details>
